### PR TITLE
fix a bug in inference_with_transformers.py, by huzengjie

### DIFF
--- a/inference/inference_with_transformers.py
+++ b/inference/inference_with_transformers.py
@@ -23,7 +23,7 @@ def main():
     ).eval()
     tokenizer = AutoTokenizer.from_pretrained(args.model_path, trust_remote_code=True, use_fast=False)
 
-    pixel_values = [load_image(img_path, max_num=12).to(torch.bfloat16).cuda() for img_path in args.image_path]
+    pixel_values = [load_image(img_path, max_num=12).to(torch.bfloat16).cuda() for img_path in args.image_paths]
     if len(pixel_values) > 1:
         pixel_values = torch.cat(pixel_values, dim=0)
         num_patches_list = [img.size(0) for img in pixel_values]


### PR DESCRIPTION
In the file inference_with_transformers.py, at line 26, `pixel_values = [load_image(img_path, max_num=12).to(torch.bfloat16).cuda() for img_path in args.image_path]` should be corrected to `pixel_values = [load_image(img_path, max_num=12).to(torch.bfloat16).cuda() for img_path in args.image_paths]`, because the command-line argument is named `image_paths`, not `image_path`.